### PR TITLE
Queue (Connection) monitoring and deep Process Group traversal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /config.yml
 /nifi_exporter
 /*.tar.gz
+/debug

--- a/README.md
+++ b/README.md
@@ -163,6 +163,15 @@ nifi_jvm_used_non_heap_bytes{env="testing",node_id="aggregate"} 1.9291444e+08
 # HELP nifi_os_info Operating system version info.
 # TYPE nifi_os_info gauge
 nifi_os_info{arch="amd64",env="testing",name="Linux",node_id="aggregate",version="4.14.72-73.55.amzn2.x86_64"} 1
+# HELP nifi_conn_flow_files_queued The number of FlowFiles that are currently queued in the connection
+# TYPE nifi_conn_flow_files_queued gauge
+nifi_conn_flow_files_queued{connection_id="026073af-c1c7-3d0e-2b43-e8baf6bb875b",connection_name="success",destination_name="in",env="testing",group_id="57b9c87e-7ee2-3cf1-2a76-5d75762bb2dd",node_id="aggregate",source_name="GenerateFlowFile"} 0
+nifi_conn_flow_files_queued{connection_id="06e8674b-a9a2-300a-5fea-3bcb312a7a0e",connection_name="failure",destination_name="fail5",env="testing",group_id="053742a0-5d93-379d-8232-ff6e6c21794d",node_id="aggregate",source_name="ExecuteSQL"} 4
+nifi_conn_flow_files_queued{connection_id="0818d0fd-9d0f-36b4-db68-596dfe02569e",connection_name="success",destination_name="out",env="testing",group_id="48f00c1b-c9c7-30cf-e3f8-52f0745f3dfd",node_id="aggregate",source_name="PutDistributedMapCache"} 0
+nifi_conn_flow_files_queued{connection_id="0bd6ab8a-29f8-37df-b345-16bdcf1abb9a",connection_name="success",destination_name="ExecuteScript",env="testing",group_id="263a63da-e085-3f02-1818-f5dfaa5504f0",node_id="aggregate",source_name="Set Credentials & Properties"} 0
+nifi_conn_flow_files_queued{connection_id="134df201-97bf-3eed-f937-445c48af300d",connection_name="splits",destination_name="ExtractText",env="testing",group_id="d99c18ca-e627-3085-7280-3aabf4c44eba",node_id="aggregate",source_name="SplitText"} 0
+nifi_conn_flow_files_queued{connection_id="16122638-c888-3192-a3f2-c6578fa7bced",connection_name="Response",destination_name="RouteOnContent",env="testing",group_id="053742a0-5d93-379d-8232-ff6e6c21794d",node_id="aggregate",source_name="InvokeHTTP"} 0
+nifi_conn_flow_files_queued{connection_id="1d681a65-c462-30eb-0f17-c56423642902",connection_name="No Retry, Failure",destination_name="UpdateAttribute",env="testing",group_id="053742a0-5d93-379d-8232-ff6e6c21794d",node_id="aggregate",source_name="InvokeHTTP"} 0
 # HELP nifi_pg_active_thread_count The active thread count for this process group.
 # TYPE nifi_pg_active_thread_count gauge
 nifi_pg_active_thread_count{env="testing",group="my_processor_group",node_id="aggregate"} 0

--- a/main.go
+++ b/main.go
@@ -117,6 +117,9 @@ func start(config *Configuration) error {
 		if err := prometheus.DefaultRegisterer.Register(collectors.NewProcessGroupsCollector(api, node.Labels)); err != nil {
 			return errors.Annotate(err, "Couldn't register process groups collector.")
 		}
+		if err := prometheus.DefaultRegisterer.Register(collectors.NewConnectionsCollector(api, node.Labels)); err != nil {
+			return errors.Annotate(err, "Couldn't register connections collector.")
+		}
 	}
 
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {

--- a/nifi/client/client.go
+++ b/nifi/client/client.go
@@ -116,14 +116,6 @@ func (c *Client) GetProcessGroups(parentID string) ([]ProcessGroupEntity, error)
 	return entity.ProcessGroups, nil
 }
 
-// func (c *Client) GetConnections(parentID string) ([]ConnectionEntity, error) {
-// 	var entity ConnectionsEntity
-// 	if err := c.request("/process-groups/"+connectionID+"/connections", nil, &entity); err != nil {
-// 		return nil, errors.Trace(err)
-// 	}
-// 	return entity.Connections, nil
-// }
-
 // GetConnections traverses the process group hierarchy returning information about
 // all connections
 func (c *Client) GetConnections(parentID string) ([]ConnectionEntity, error) {

--- a/nifi/client/entities.go
+++ b/nifi/client/entities.go
@@ -414,6 +414,117 @@ type ProcessGroupsEntity struct {
 	ProcessGroups []ProcessGroupEntity `json:"processGroups"`
 }
 
+// ConnectionEndPointDTO represents a connection's source and/or destination
+type ConnectionEndPointDTO struct {
+	//The ID
+	ID string `json:"id"`
+	// The type
+	Type string `json:"type"`
+	// The group ID
+	GroupID string `json:"groupId"`
+	// The name
+	Name string `json:"name"`
+	//Is this connection running?
+	Running bool `json:"running"`
+	// User comments on this connection
+	Comments string `json:"comments"`
+}
+
+// ConnectionDTO is the connection component
+type ConnectionDTO struct {
+	// The id of the component.
+	ID string `json:"id"`
+	// The id of parent process group of this component if applicable.
+	ParentGroupID string `json:"parentGroupId"`
+
+	// The source of the connection
+	Source ConnectionEndPointDTO `json:"source"`
+	// The destination of the connection
+	Destination ConnectionEndPointDTO `json:"destination"`
+	// The Name
+	Name string `json:"name"`
+	// The label Index
+	LabelIndex int `json:"labelIndex"`
+	// The zindex of this connection
+	ZIndex int `json:"zIndex"`
+	// Valid relationships for this connection
+	SelectedRelationships []string `json:"selectedRelationships"`
+	// Potential relationships for this connection
+	AvailableRelationships []string `json:"availableRelationships"`
+	// Threshold for back pressure objects
+	BackPressureObjectThreshold int `json:"backPressureObjectThreshold"`
+	// Threshold for backpressure size
+	BackPressureDataSizeThreshold string `json:"backPressureDataSizeThreshold"`
+	// When to the flows
+	FlowFileExpiration string `json:"flowFileExpiration"`
+	// The bends in the connection layout
+	Bends []PositionDTO `json:"bends"`
+	// The comparators used to prioritize the queue
+	Prioritizers []string `json:"prioritizers"`
+}
+
+// ConnectionStatusDTO represents the status of a connection
+type ConnectionStatusDTO struct {
+	// The ID of the Connection
+	ID string `json:"id"`
+	// The GroupID of the Connection
+	GroupID string `json:"groupId"`
+	// The name of the Connection
+	Name string `json:"name"`
+	// The time the status for the process group was last refreshed.
+	StatsLastRefreshed string `json:"statsLastRefreshed"`
+	SourceID           string `json:"sourceId"`
+	SourceName         string `json:"sourceName"`
+	DestinationID      string `json:"destinationId"`
+	DestinationName    string `json:"destinationName"`
+
+	// The aggregate status of all nodes in the cluster
+	AggregateSnapshot *ConnectionStatusSnapshotDTO `json:"aggregateSnapshot"`
+	// The status reported by each node in the cluster. If the NiFi instance is a standalone instance,
+	// rather than a clustered instance, this value may be null.
+	NodeSnapshots []NodeProcessGroupStatusSnapshotDTO `json:"nodeSnapshots"`
+}
+
+// ConnectionEntity represents a NiFi connection
+type ConnectionEntity struct {
+	// The revision for this request/response. The revision is required for any mutable flow requests and
+	// is included in all responses.
+	Revision RevisionDTO `json:"revision"`
+	// The id of the component.
+	ID string `json:"id"`
+	// The URI for futures requests to the component.
+	URI string `json:"uri"`
+	// The permissions for this component.
+	Permissions PermissionsDTO `json:"permissions"`
+	// The Connection.
+	Component ConnectionDTO `json:"component"`
+	// The status of the process group.
+	Status ConnectionStatusDTO `json:"status"`
+	// The bends in the connection layout
+	Bends []PositionDTO `json:"bends"`
+
+	// The label Index
+	LabelIndex int `json:"labelIndex"`
+	// The zindex of this connection
+	ZIndex int `json:"zIndex"`
+	// Connection source id
+	SourceID string `json:"sourceId"`
+	// Connection source group id
+	SourceGroupID string `json:"sourceGroupId"`
+	// Connection source type
+	SourceType string `json:"sourceType"`
+	// Connection destination id
+	DestinationID string `json:"destinationId"`
+	// Connection destination group id
+	DestinationGroupID string `json:"destinationGroupId"`
+	// Connection destination type
+	DestinationType string `json:"destinationType"`
+}
+
+type ConnectionsEntity struct {
+	Connections []ConnectionEntity `json:"connections"`
+}
+
 type CounterDTO struct {
 	// The id of the counter.
 	ID string `json:"id"`

--- a/nifi/collectors/common.go
+++ b/nifi/collectors/common.go
@@ -2,3 +2,4 @@ package collectors
 
 const MetricNamePrefix = "nifi_"
 const AggregateNodeID = "aggregate"
+const rootProcessGroupID = "root"

--- a/nifi/collectors/connections.go
+++ b/nifi/collectors/connections.go
@@ -9,36 +9,18 @@ import (
 type ConnectionsCollector struct {
 	api *client.Client
 
-	queuedCount *prometheus.Desc
-	// bulletin5mCount *prometheus.Desc
-	// componentCount  *prometheus.Desc
-
-	// inFlowFiles5mCount          *prometheus.Desc
-	// inBytes5mCount              *prometheus.Desc
-	// queuedFlowFilesCount        *prometheus.Desc
-	// queuedBytes                 *prometheus.Desc
-	// readBytes5mCount            *prometheus.Desc
-	// writtenBytes5mCount         *prometheus.Desc
-	// outFlowFiles5mCount         *prometheus.Desc
-	// outBytes5mCount             *prometheus.Desc
-	// transferredFlowFiles5mCount *prometheus.Desc
-	// transferredBytes5mCount     *prometheus.Desc
-	// receivedBytes5mCount        *prometheus.Desc
-	// receivedFlowFiles5mCount    *prometheus.Desc
-	// sentBytes5mCount            *prometheus.Desc
-	// sentFlowFiles5mCount        *prometheus.Desc
-	// activeThreadCount           *prometheus.Desc
+	flowFilesQueued *prometheus.Desc
 }
 
 // NewConnectionsCollector initialises a collector
 func NewConnectionsCollector(api *client.Client, labels map[string]string) *ConnectionsCollector {
 	prefix := MetricNamePrefix + "conn_"
-	statLabels := []string{"node_id", "source_name", "destination_name"}
+	statLabels := []string{"node_id", "connection_name", "connection_id", "group_id", "source_name", "destination_name"}
 	return &ConnectionsCollector{
 		api: api,
-		queuedCount: prometheus.NewDesc(
-			prefix+"queued_count",
-			"Number of items queued in connection",
+		flowFilesQueued: prometheus.NewDesc(
+			prefix+"flow_files_queued",
+			"The number of FlowFiles that are currently queued in the connection",
 			statLabels,
 			labels,
 		),
@@ -47,14 +29,14 @@ func NewConnectionsCollector(api *client.Client, labels map[string]string) *Conn
 
 // Describe makes the metrics descriptions available to Prometheus
 func (c *ConnectionsCollector) Describe(ch chan<- *prometheus.Desc) {
-	ch <- c.queuedCount
+	ch <- c.flowFilesQueued
 }
 
 // Collect retrieves the data that for the metrics
 func (c *ConnectionsCollector) Collect(ch chan<- prometheus.Metric) {
-	entities, err := c.api.GetProcessGroups(rootProcessGroupID)
+	entities, err := c.api.GetConnections(rootProcessGroupID)
 	if err != nil {
-		ch <- prometheus.NewInvalidMetric(c.queuedCount, err)
+		ch <- prometheus.NewInvalidMetric(c.flowFilesQueued, err)
 		return
 	}
 
@@ -63,169 +45,23 @@ func (c *ConnectionsCollector) Collect(ch chan<- prometheus.Metric) {
 	}
 }
 
-func (c *ConnectionsCollector) collect(ch chan<- prometheus.Metric, entity *client.ProcessGroupEntity) {
-	// bulletinCount := map[string]int{
-	// 	"INFO":    0,
-	// 	"WARNING": 0,
-	// 	"ERROR":   0,
-	// }
-	// for i := range entity.Bulletins {
-	// 	bulletinCount[entity.Bulletins[i].Bulletin.Level]++
-	// }
-	// for level, count := range bulletinCount {
-	// 	ch <- prometheus.MustNewConstMetric(
-	// 		c.bulletin5mCount,
-	// 		prometheus.GaugeValue,
-	// 		float64(count),
-	// 		entity.Component.Name,
-	// 		level,
-	// 	)
-	// }
+func (c *ConnectionsCollector) collect(ch chan<- prometheus.Metric, entity *client.ConnectionEntity) {
+	nodes := make(map[string]*client.ConnectionStatusSnapshotDTO)
+	if entity.Status.AggregateSnapshot != nil {
+		nodes[AggregateNodeID] = entity.Status.AggregateSnapshot
+	}
 
-	// nodes := make(map[string]*client.ProcessGroupStatusSnapshotDTO)
-	// if len(entity.Status.NodeSnapshots) > 0 {
-	// 	for i := range entity.Status.NodeSnapshots {
-	// 		snapshot := &entity.Status.NodeSnapshots[i]
-	// 		nodes[snapshot.NodeID] = &snapshot.StatusSnapshot
-	// 	}
-	// } else if entity.Status.AggregateSnapshot != nil {
-	// 	nodes[AggregateNodeID] = entity.Status.AggregateSnapshot
-	// }
-
-	// ch <- prometheus.MustNewConstMetric(
-	// 	c.componentCount,
-	// 	prometheus.GaugeValue,
-	// 	float64(entity.RunningCount),
-	// 	entity.Component.Name,
-	// 	"running",
-	// )
-	// ch <- prometheus.MustNewConstMetric(
-	// 	c.componentCount,
-	// 	prometheus.GaugeValue,
-	// 	float64(entity.StoppedCount),
-	// 	entity.Component.Name,
-	// 	"stopped",
-	// )
-	// ch <- prometheus.MustNewConstMetric(
-	// 	c.componentCount,
-	// 	prometheus.GaugeValue,
-	// 	float64(entity.InvalidCount),
-	// 	entity.Component.Name,
-	// 	"invalid",
-	// )
-	// ch <- prometheus.MustNewConstMetric(
-	// 	c.componentCount,
-	// 	prometheus.GaugeValue,
-	// 	float64(entity.DisabledCount),
-	// 	entity.Component.Name,
-	// 	"disabled",
-	// )
-
-	// for nodeID, snapshot := range nodes {
-	// 	ch <- prometheus.MustNewConstMetric(
-	// 		c.inFlowFiles5mCount,
-	// 		prometheus.GaugeValue,
-	// 		float64(snapshot.FlowFilesIn),
-	// 		nodeID,
-	// 		snapshot.Name,
-	// 	)
-	// 	ch <- prometheus.MustNewConstMetric(
-	// 		c.inBytes5mCount,
-	// 		prometheus.GaugeValue,
-	// 		float64(snapshot.BytesIn),
-	// 		nodeID,
-	// 		snapshot.Name,
-	// 	)
-	// 	ch <- prometheus.MustNewConstMetric(
-	// 		c.queuedFlowFilesCount,
-	// 		prometheus.GaugeValue,
-	// 		float64(snapshot.FlowFilesQueued),
-	// 		nodeID,
-	// 		snapshot.Name,
-	// 	)
-	// 	ch <- prometheus.MustNewConstMetric(
-	// 		c.queuedBytes,
-	// 		prometheus.GaugeValue,
-	// 		float64(snapshot.BytesQueued),
-	// 		nodeID,
-	// 		snapshot.Name,
-	// 	)
-	// 	ch <- prometheus.MustNewConstMetric(
-	// 		c.readBytes5mCount,
-	// 		prometheus.GaugeValue,
-	// 		float64(snapshot.BytesRead),
-	// 		nodeID,
-	// 		snapshot.Name,
-	// 	)
-	// 	ch <- prometheus.MustNewConstMetric(
-	// 		c.writtenBytes5mCount,
-	// 		prometheus.GaugeValue,
-	// 		float64(snapshot.BytesWritten),
-	// 		nodeID,
-	// 		snapshot.Name,
-	// 	)
-	// 	ch <- prometheus.MustNewConstMetric(
-	// 		c.outFlowFiles5mCount,
-	// 		prometheus.GaugeValue,
-	// 		float64(snapshot.FlowFilesOut),
-	// 		nodeID,
-	// 		snapshot.Name,
-	// 	)
-	// 	ch <- prometheus.MustNewConstMetric(
-	// 		c.outBytes5mCount,
-	// 		prometheus.GaugeValue,
-	// 		float64(snapshot.BytesOut),
-	// 		nodeID,
-	// 		snapshot.Name,
-	// 	)
-	// 	ch <- prometheus.MustNewConstMetric(
-	// 		c.transferredFlowFiles5mCount,
-	// 		prometheus.GaugeValue,
-	// 		float64(snapshot.FlowFilesTransferred),
-	// 		nodeID,
-	// 		snapshot.Name,
-	// 	)
-	// 	ch <- prometheus.MustNewConstMetric(
-	// 		c.transferredBytes5mCount,
-	// 		prometheus.GaugeValue,
-	// 		float64(snapshot.BytesTransferred),
-	// 		nodeID,
-	// 		snapshot.Name,
-	// 	)
-	// 	ch <- prometheus.MustNewConstMetric(
-	// 		c.receivedBytes5mCount,
-	// 		prometheus.GaugeValue,
-	// 		float64(snapshot.BytesReceived),
-	// 		nodeID,
-	// 		snapshot.Name,
-	// 	)
-	// 	ch <- prometheus.MustNewConstMetric(
-	// 		c.receivedFlowFiles5mCount,
-	// 		prometheus.GaugeValue,
-	// 		float64(snapshot.FlowFilesReceived),
-	// 		nodeID,
-	// 		snapshot.Name,
-	// 	)
-	// 	ch <- prometheus.MustNewConstMetric(
-	// 		c.sentBytes5mCount,
-	// 		prometheus.GaugeValue,
-	// 		float64(snapshot.BytesSent),
-	// 		nodeID,
-	// 		snapshot.Name,
-	// 	)
-	// 	ch <- prometheus.MustNewConstMetric(
-	// 		c.sentFlowFiles5mCount,
-	// 		prometheus.GaugeValue,
-	// 		float64(snapshot.FlowFilesSent),
-	// 		nodeID,
-	// 		snapshot.Name,
-	// 	)
-	// 	ch <- prometheus.MustNewConstMetric(
-	// 		c.activeThreadCount,
-	// 		prometheus.GaugeValue,
-	// 		float64(snapshot.ActiveThreadCount),
-	// 		nodeID,
-	// 		snapshot.Name,
-	// 	)
-	// }
+	for nodeID, snapshot := range nodes {
+		ch <- prometheus.MustNewConstMetric(
+			c.flowFilesQueued,
+			prometheus.GaugeValue,
+			float64(snapshot.FlowFilesQueued),
+			nodeID,
+			snapshot.Name,
+			snapshot.ID,
+			snapshot.GroupID,
+			snapshot.SourceName,
+			snapshot.DestinationName,
+		)
+	}
 }

--- a/nifi/collectors/connections.go
+++ b/nifi/collectors/connections.go
@@ -1,0 +1,231 @@
+package collectors
+
+import (
+	"github.com/msiedlarek/nifi_exporter/nifi/client"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// ConnectionsCollector holds the metrics for each connection
+type ConnectionsCollector struct {
+	api *client.Client
+
+	queuedCount *prometheus.Desc
+	// bulletin5mCount *prometheus.Desc
+	// componentCount  *prometheus.Desc
+
+	// inFlowFiles5mCount          *prometheus.Desc
+	// inBytes5mCount              *prometheus.Desc
+	// queuedFlowFilesCount        *prometheus.Desc
+	// queuedBytes                 *prometheus.Desc
+	// readBytes5mCount            *prometheus.Desc
+	// writtenBytes5mCount         *prometheus.Desc
+	// outFlowFiles5mCount         *prometheus.Desc
+	// outBytes5mCount             *prometheus.Desc
+	// transferredFlowFiles5mCount *prometheus.Desc
+	// transferredBytes5mCount     *prometheus.Desc
+	// receivedBytes5mCount        *prometheus.Desc
+	// receivedFlowFiles5mCount    *prometheus.Desc
+	// sentBytes5mCount            *prometheus.Desc
+	// sentFlowFiles5mCount        *prometheus.Desc
+	// activeThreadCount           *prometheus.Desc
+}
+
+// NewConnectionsCollector initialises a collector
+func NewConnectionsCollector(api *client.Client, labels map[string]string) *ConnectionsCollector {
+	prefix := MetricNamePrefix + "conn_"
+	statLabels := []string{"node_id", "source_name", "destination_name"}
+	return &ConnectionsCollector{
+		api: api,
+		queuedCount: prometheus.NewDesc(
+			prefix+"queued_count",
+			"Number of items queued in connection",
+			statLabels,
+			labels,
+		),
+	}
+}
+
+// Describe makes the metrics descriptions available to Prometheus
+func (c *ConnectionsCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- c.queuedCount
+}
+
+// Collect retrieves the data that for the metrics
+func (c *ConnectionsCollector) Collect(ch chan<- prometheus.Metric) {
+	entities, err := c.api.GetProcessGroups(rootProcessGroupID)
+	if err != nil {
+		ch <- prometheus.NewInvalidMetric(c.queuedCount, err)
+		return
+	}
+
+	for i := range entities {
+		c.collect(ch, &entities[i])
+	}
+}
+
+func (c *ConnectionsCollector) collect(ch chan<- prometheus.Metric, entity *client.ProcessGroupEntity) {
+	// bulletinCount := map[string]int{
+	// 	"INFO":    0,
+	// 	"WARNING": 0,
+	// 	"ERROR":   0,
+	// }
+	// for i := range entity.Bulletins {
+	// 	bulletinCount[entity.Bulletins[i].Bulletin.Level]++
+	// }
+	// for level, count := range bulletinCount {
+	// 	ch <- prometheus.MustNewConstMetric(
+	// 		c.bulletin5mCount,
+	// 		prometheus.GaugeValue,
+	// 		float64(count),
+	// 		entity.Component.Name,
+	// 		level,
+	// 	)
+	// }
+
+	// nodes := make(map[string]*client.ProcessGroupStatusSnapshotDTO)
+	// if len(entity.Status.NodeSnapshots) > 0 {
+	// 	for i := range entity.Status.NodeSnapshots {
+	// 		snapshot := &entity.Status.NodeSnapshots[i]
+	// 		nodes[snapshot.NodeID] = &snapshot.StatusSnapshot
+	// 	}
+	// } else if entity.Status.AggregateSnapshot != nil {
+	// 	nodes[AggregateNodeID] = entity.Status.AggregateSnapshot
+	// }
+
+	// ch <- prometheus.MustNewConstMetric(
+	// 	c.componentCount,
+	// 	prometheus.GaugeValue,
+	// 	float64(entity.RunningCount),
+	// 	entity.Component.Name,
+	// 	"running",
+	// )
+	// ch <- prometheus.MustNewConstMetric(
+	// 	c.componentCount,
+	// 	prometheus.GaugeValue,
+	// 	float64(entity.StoppedCount),
+	// 	entity.Component.Name,
+	// 	"stopped",
+	// )
+	// ch <- prometheus.MustNewConstMetric(
+	// 	c.componentCount,
+	// 	prometheus.GaugeValue,
+	// 	float64(entity.InvalidCount),
+	// 	entity.Component.Name,
+	// 	"invalid",
+	// )
+	// ch <- prometheus.MustNewConstMetric(
+	// 	c.componentCount,
+	// 	prometheus.GaugeValue,
+	// 	float64(entity.DisabledCount),
+	// 	entity.Component.Name,
+	// 	"disabled",
+	// )
+
+	// for nodeID, snapshot := range nodes {
+	// 	ch <- prometheus.MustNewConstMetric(
+	// 		c.inFlowFiles5mCount,
+	// 		prometheus.GaugeValue,
+	// 		float64(snapshot.FlowFilesIn),
+	// 		nodeID,
+	// 		snapshot.Name,
+	// 	)
+	// 	ch <- prometheus.MustNewConstMetric(
+	// 		c.inBytes5mCount,
+	// 		prometheus.GaugeValue,
+	// 		float64(snapshot.BytesIn),
+	// 		nodeID,
+	// 		snapshot.Name,
+	// 	)
+	// 	ch <- prometheus.MustNewConstMetric(
+	// 		c.queuedFlowFilesCount,
+	// 		prometheus.GaugeValue,
+	// 		float64(snapshot.FlowFilesQueued),
+	// 		nodeID,
+	// 		snapshot.Name,
+	// 	)
+	// 	ch <- prometheus.MustNewConstMetric(
+	// 		c.queuedBytes,
+	// 		prometheus.GaugeValue,
+	// 		float64(snapshot.BytesQueued),
+	// 		nodeID,
+	// 		snapshot.Name,
+	// 	)
+	// 	ch <- prometheus.MustNewConstMetric(
+	// 		c.readBytes5mCount,
+	// 		prometheus.GaugeValue,
+	// 		float64(snapshot.BytesRead),
+	// 		nodeID,
+	// 		snapshot.Name,
+	// 	)
+	// 	ch <- prometheus.MustNewConstMetric(
+	// 		c.writtenBytes5mCount,
+	// 		prometheus.GaugeValue,
+	// 		float64(snapshot.BytesWritten),
+	// 		nodeID,
+	// 		snapshot.Name,
+	// 	)
+	// 	ch <- prometheus.MustNewConstMetric(
+	// 		c.outFlowFiles5mCount,
+	// 		prometheus.GaugeValue,
+	// 		float64(snapshot.FlowFilesOut),
+	// 		nodeID,
+	// 		snapshot.Name,
+	// 	)
+	// 	ch <- prometheus.MustNewConstMetric(
+	// 		c.outBytes5mCount,
+	// 		prometheus.GaugeValue,
+	// 		float64(snapshot.BytesOut),
+	// 		nodeID,
+	// 		snapshot.Name,
+	// 	)
+	// 	ch <- prometheus.MustNewConstMetric(
+	// 		c.transferredFlowFiles5mCount,
+	// 		prometheus.GaugeValue,
+	// 		float64(snapshot.FlowFilesTransferred),
+	// 		nodeID,
+	// 		snapshot.Name,
+	// 	)
+	// 	ch <- prometheus.MustNewConstMetric(
+	// 		c.transferredBytes5mCount,
+	// 		prometheus.GaugeValue,
+	// 		float64(snapshot.BytesTransferred),
+	// 		nodeID,
+	// 		snapshot.Name,
+	// 	)
+	// 	ch <- prometheus.MustNewConstMetric(
+	// 		c.receivedBytes5mCount,
+	// 		prometheus.GaugeValue,
+	// 		float64(snapshot.BytesReceived),
+	// 		nodeID,
+	// 		snapshot.Name,
+	// 	)
+	// 	ch <- prometheus.MustNewConstMetric(
+	// 		c.receivedFlowFiles5mCount,
+	// 		prometheus.GaugeValue,
+	// 		float64(snapshot.FlowFilesReceived),
+	// 		nodeID,
+	// 		snapshot.Name,
+	// 	)
+	// 	ch <- prometheus.MustNewConstMetric(
+	// 		c.sentBytes5mCount,
+	// 		prometheus.GaugeValue,
+	// 		float64(snapshot.BytesSent),
+	// 		nodeID,
+	// 		snapshot.Name,
+	// 	)
+	// 	ch <- prometheus.MustNewConstMetric(
+	// 		c.sentFlowFiles5mCount,
+	// 		prometheus.GaugeValue,
+	// 		float64(snapshot.FlowFilesSent),
+	// 		nodeID,
+	// 		snapshot.Name,
+	// 	)
+	// 	ch <- prometheus.MustNewConstMetric(
+	// 		c.activeThreadCount,
+	// 		prometheus.GaugeValue,
+	// 		float64(snapshot.ActiveThreadCount),
+	// 		nodeID,
+	// 		snapshot.Name,
+	// 	)
+	// }
+}

--- a/nifi/collectors/processgroups.go
+++ b/nifi/collectors/processgroups.go
@@ -5,8 +5,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-const rootProcessGroupID = "root"
-
 type ProcessGroupsCollector struct {
 	api *client.Client
 
@@ -164,7 +162,7 @@ func (c *ProcessGroupsCollector) Describe(ch chan<- *prometheus.Desc) {
 }
 
 func (c *ProcessGroupsCollector) Collect(ch chan<- prometheus.Metric) {
-	entities, err := c.api.GetProcessGroups(rootProcessGroupID)
+	entities, err := c.api.GetDeepProcessGroups(rootProcessGroupID)
 	if err != nil {
 		ch <- prometheus.NewInvalidMetric(c.componentCount, err)
 		return

--- a/sample-config.yml
+++ b/sample-config.yml
@@ -2,28 +2,33 @@
 exporter:
   listenAddress: 127.0.0.1:9103
 nodes:
-  - url: http://test-nifi.example.com:8080
-    username: nifitest
-    password: abc123
-    labels:
-      env: testing
-  - url: https://nifi.example.com
-    username: nifiuser
-    password: 123456
-    labels:
-      env: production
-    caCertificates: |
-      -----BEGIN CERTIFICATE-----
-      MIICLDCCAdKgAwIBAgIBADAKBggqhkjOPQQDAjB9MQswCQYDVQQGEwJCRTEPMA0G
-      A1UEChMGR251VExTMSUwIwYDVQQLExxHbnVUTFMgY2VydGlmaWNhdGUgYXV0aG9y
-      aXR5MQ8wDQYDVQQIEwZMZXV2ZW4xJTAjBgNVBAMTHEdudVRMUyBjZXJ0aWZpY2F0
-      ZSBhdXRob3JpdHkwHhcNMTEwNTIzMjAzODIxWhcNMTIxMjIyMDc0MTUxWjB9MQsw
-      CQYDVQQGEwJCRTEPMA0GA1UEChMGR251VExTMSUwIwYDVQQLExxHbnVUTFMgY2Vy
-      dGlmaWNhdGUgYXV0aG9yaXR5MQ8wDQYDVQQIEwZMZXV2ZW4xJTAjBgNVBAMTHEdu
-      dVRMUyBjZXJ0aWZpY2F0ZSBhdXRob3JpdHkwWTATBgcqhkjOPQIBBggqhkjOPQMB
-      BwNCAARS2I0jiuNn14Y2sSALCX3IybqiIJUvxUpj+oNfzngvj/Niyv2394BWnW4X
-      uQ4RTEiywK87WRcWMGgJB5kX/t2no0MwQTAPBgNVHRMBAf8EBTADAQH/MA8GA1Ud
-      DwEB/wQFAwMHBgAwHQYDVR0OBBYEFPC0gf6YEr+1KLlkQAPLzB9mTigDMAoGCCqG
-      SM49BAMCA0gAMEUCIDGuwD1KPyG+hRf88MeyMQcqOFZD0TbVleF+UsAGQ4enAiEA
-      l4wOuDwKQa+upc8GftXE2C//4mKANBC6It01gUaTIpo=
-      -----END CERTIFICATE-----
+   - url: http://localhost:8080
+     username: xxxxxx
+     password: xxxxxx
+     labels:
+       env: testing
+  # - url: http://test-nifi.example.com:8080
+  #   username: nifitest
+  #   password: abc123
+  #   labels:
+  #     env: testing
+  # - url: https://nifi.example.com
+  #   username: nifiuser
+  #   password: 123456
+  #   labels:
+  #     env: production
+  #   caCertificates: |
+  #     -----BEGIN CERTIFICATE-----
+  #     MIICLDCCAdKgAwIBAgIBADAKBggqhkjOPQQDAjB9MQswCQYDVQQGEwJCRTEPMA0G
+  #     A1UEChMGR251VExTMSUwIwYDVQQLExxHbnVUTFMgY2VydGlmaWNhdGUgYXV0aG9y
+  #     aXR5MQ8wDQYDVQQIEwZMZXV2ZW4xJTAjBgNVBAMTHEdudVRMUyBjZXJ0aWZpY2F0
+  #     ZSBhdXRob3JpdHkwHhcNMTEwNTIzMjAzODIxWhcNMTIxMjIyMDc0MTUxWjB9MQsw
+  #     CQYDVQQGEwJCRTEPMA0GA1UEChMGR251VExTMSUwIwYDVQQLExxHbnVUTFMgY2Vy
+  #     dGlmaWNhdGUgYXV0aG9yaXR5MQ8wDQYDVQQIEwZMZXV2ZW4xJTAjBgNVBAMTHEdu
+  #     dVRMUyBjZXJ0aWZpY2F0ZSBhdXRob3JpdHkwWTATBgcqhkjOPQIBBggqhkjOPQMB
+  #     BwNCAARS2I0jiuNn14Y2sSALCX3IybqiIJUvxUpj+oNfzngvj/Niyv2394BWnW4X
+  #     uQ4RTEiywK87WRcWMGgJB5kX/t2no0MwQTAPBgNVHRMBAf8EBTADAQH/MA8GA1Ud
+  #     DwEB/wQFAwMHBgAwHQYDVR0OBBYEFPC0gf6YEr+1KLlkQAPLzB9mTigDMAoGCCqG
+  #     SM49BAMCA0gAMEUCIDGuwD1KPyG+hRf88MeyMQcqOFZD0TbVleF+UsAGQ4enAiEA
+  #     l4wOuDwKQa+upc8GftXE2C//4mKANBC6It01gUaTIpo=
+  #     -----END CERTIFICATE-----

--- a/sample-config.yml
+++ b/sample-config.yml
@@ -7,28 +7,28 @@ nodes:
      password: xxxxxx
      labels:
        env: testing
-  # - url: http://test-nifi.example.com:8080
-  #   username: nifitest
-  #   password: abc123
-  #   labels:
-  #     env: testing
-  # - url: https://nifi.example.com
-  #   username: nifiuser
-  #   password: 123456
-  #   labels:
-  #     env: production
-  #   caCertificates: |
-  #     -----BEGIN CERTIFICATE-----
-  #     MIICLDCCAdKgAwIBAgIBADAKBggqhkjOPQQDAjB9MQswCQYDVQQGEwJCRTEPMA0G
-  #     A1UEChMGR251VExTMSUwIwYDVQQLExxHbnVUTFMgY2VydGlmaWNhdGUgYXV0aG9y
-  #     aXR5MQ8wDQYDVQQIEwZMZXV2ZW4xJTAjBgNVBAMTHEdudVRMUyBjZXJ0aWZpY2F0
-  #     ZSBhdXRob3JpdHkwHhcNMTEwNTIzMjAzODIxWhcNMTIxMjIyMDc0MTUxWjB9MQsw
-  #     CQYDVQQGEwJCRTEPMA0GA1UEChMGR251VExTMSUwIwYDVQQLExxHbnVUTFMgY2Vy
-  #     dGlmaWNhdGUgYXV0aG9yaXR5MQ8wDQYDVQQIEwZMZXV2ZW4xJTAjBgNVBAMTHEdu
-  #     dVRMUyBjZXJ0aWZpY2F0ZSBhdXRob3JpdHkwWTATBgcqhkjOPQIBBggqhkjOPQMB
-  #     BwNCAARS2I0jiuNn14Y2sSALCX3IybqiIJUvxUpj+oNfzngvj/Niyv2394BWnW4X
-  #     uQ4RTEiywK87WRcWMGgJB5kX/t2no0MwQTAPBgNVHRMBAf8EBTADAQH/MA8GA1Ud
-  #     DwEB/wQFAwMHBgAwHQYDVR0OBBYEFPC0gf6YEr+1KLlkQAPLzB9mTigDMAoGCCqG
-  #     SM49BAMCA0gAMEUCIDGuwD1KPyG+hRf88MeyMQcqOFZD0TbVleF+UsAGQ4enAiEA
-  #     l4wOuDwKQa+upc8GftXE2C//4mKANBC6It01gUaTIpo=
-  #     -----END CERTIFICATE-----
+  - url: http://test-nifi.example.com:8080
+    username: nifitest
+    password: abc123
+    labels:
+      env: testing
+  - url: https://nifi.example.com
+    username: nifiuser
+    password: 123456
+    labels:
+      env: production
+    caCertificates: |
+      -----BEGIN CERTIFICATE-----
+      MIICLDCCAdKgAwIBAgIBADAKBggqhkjOPQQDAjB9MQswCQYDVQQGEwJCRTEPMA0G
+      A1UEChMGR251VExTMSUwIwYDVQQLExxHbnVUTFMgY2VydGlmaWNhdGUgYXV0aG9y
+      aXR5MQ8wDQYDVQQIEwZMZXV2ZW4xJTAjBgNVBAMTHEdudVRMUyBjZXJ0aWZpY2F0
+      ZSBhdXRob3JpdHkwHhcNMTEwNTIzMjAzODIxWhcNMTIxMjIyMDc0MTUxWjB9MQsw
+      CQYDVQQGEwJCRTEPMA0GA1UEChMGR251VExTMSUwIwYDVQQLExxHbnVUTFMgY2Vy
+      dGlmaWNhdGUgYXV0aG9yaXR5MQ8wDQYDVQQIEwZMZXV2ZW4xJTAjBgNVBAMTHEdu
+      dVRMUyBjZXJ0aWZpY2F0ZSBhdXRob3JpdHkwWTATBgcqhkjOPQIBBggqhkjOPQMB
+      BwNCAARS2I0jiuNn14Y2sSALCX3IybqiIJUvxUpj+oNfzngvj/Niyv2394BWnW4X
+      uQ4RTEiywK87WRcWMGgJB5kX/t2no0MwQTAPBgNVHRMBAf8EBTADAQH/MA8GA1Ud
+      DwEB/wQFAwMHBgAwHQYDVR0OBBYEFPC0gf6YEr+1KLlkQAPLzB9mTigDMAoGCCqG
+      SM49BAMCA0gAMEUCIDGuwD1KPyG+hRf88MeyMQcqOFZD0TbVleF+UsAGQ4enAiEA
+      l4wOuDwKQa+upc8GftXE2C//4mKANBC6It01gUaTIpo=
+      -----END CERTIFICATE-----

--- a/sample-config.yml
+++ b/sample-config.yml
@@ -2,33 +2,28 @@
 exporter:
   listenAddress: 127.0.0.1:9103
 nodes:
-   - url: http://localhost:8080
-     username: xxxxxx
-     password: xxxxxx
-     labels:
-       env: testing
-   - url: http://test-nifi.example.com:8080
-     username: nifitest
-     password: abc123
-     labels:
-       env: testing
-   - url: https://nifi.example.com
-     username: nifiuser
-     password: 123456
-     labels:
-       env: production
-     caCertificates: |
-       -----BEGIN CERTIFICATE-----
-       MIICLDCCAdKgAwIBAgIBADAKBggqhkjOPQQDAjB9MQswCQYDVQQGEwJCRTEPMA0G
-       A1UEChMGR251VExTMSUwIwYDVQQLExxHbnVUTFMgY2VydGlmaWNhdGUgYXV0aG9y
-       aXR5MQ8wDQYDVQQIEwZMZXV2ZW4xJTAjBgNVBAMTHEdudVRMUyBjZXJ0aWZpY2F0
-       ZSBhdXRob3JpdHkwHhcNMTEwNTIzMjAzODIxWhcNMTIxMjIyMDc0MTUxWjB9MQsw
-       CQYDVQQGEwJCRTEPMA0GA1UEChMGR251VExTMSUwIwYDVQQLExxHbnVUTFMgY2Vy
-       dGlmaWNhdGUgYXV0aG9yaXR5MQ8wDQYDVQQIEwZMZXV2ZW4xJTAjBgNVBAMTHEdu
-       dVRMUyBjZXJ0aWZpY2F0ZSBhdXRob3JpdHkwWTATBgcqhkjOPQIBBggqhkjOPQMB
-       BwNCAARS2I0jiuNn14Y2sSALCX3IybqiIJUvxUpj+oNfzngvj/Niyv2394BWnW4X
-       uQ4RTEiywK87WRcWMGgJB5kX/t2no0MwQTAPBgNVHRMBAf8EBTADAQH/MA8GA1Ud
-       DwEB/wQFAwMHBgAwHQYDVR0OBBYEFPC0gf6YEr+1KLlkQAPLzB9mTigDMAoGCCqG
-       SM49BAMCA0gAMEUCIDGuwD1KPyG+hRf88MeyMQcqOFZD0TbVleF+UsAGQ4enAiEA
-       l4wOuDwKQa+upc8GftXE2C//4mKANBC6It01gUaTIpo=
-       -----END CERTIFICATE-----
+  - url: http://test-nifi.example.com:8080
+    username: nifitest
+    password: abc123
+    labels:
+      env: testing
+  - url: https://nifi.example.com
+    username: nifiuser
+    password: 123456
+    labels:
+      env: production
+    caCertificates: |
+      -----BEGIN CERTIFICATE-----
+      MIICLDCCAdKgAwIBAgIBADAKBggqhkjOPQQDAjB9MQswCQYDVQQGEwJCRTEPMA0G
+      A1UEChMGR251VExTMSUwIwYDVQQLExxHbnVUTFMgY2VydGlmaWNhdGUgYXV0aG9y
+      aXR5MQ8wDQYDVQQIEwZMZXV2ZW4xJTAjBgNVBAMTHEdudVRMUyBjZXJ0aWZpY2F0
+      ZSBhdXRob3JpdHkwHhcNMTEwNTIzMjAzODIxWhcNMTIxMjIyMDc0MTUxWjB9MQsw
+      CQYDVQQGEwJCRTEPMA0GA1UEChMGR251VExTMSUwIwYDVQQLExxHbnVUTFMgY2Vy
+      dGlmaWNhdGUgYXV0aG9yaXR5MQ8wDQYDVQQIEwZMZXV2ZW4xJTAjBgNVBAMTHEdu
+      dVRMUyBjZXJ0aWZpY2F0ZSBhdXRob3JpdHkwWTATBgcqhkjOPQIBBggqhkjOPQMB
+      BwNCAARS2I0jiuNn14Y2sSALCX3IybqiIJUvxUpj+oNfzngvj/Niyv2394BWnW4X
+      uQ4RTEiywK87WRcWMGgJB5kX/t2no0MwQTAPBgNVHRMBAf8EBTADAQH/MA8GA1Ud
+      DwEB/wQFAwMHBgAwHQYDVR0OBBYEFPC0gf6YEr+1KLlkQAPLzB9mTigDMAoGCCqG
+      SM49BAMCA0gAMEUCIDGuwD1KPyG+hRf88MeyMQcqOFZD0TbVleF+UsAGQ4enAiEA
+      l4wOuDwKQa+upc8GftXE2C//4mKANBC6It01gUaTIpo=
+      -----END CERTIFICATE-----

--- a/sample-config.yml
+++ b/sample-config.yml
@@ -7,28 +7,28 @@ nodes:
      password: xxxxxx
      labels:
        env: testing
-  - url: http://test-nifi.example.com:8080
-    username: nifitest
-    password: abc123
-    labels:
-      env: testing
-  - url: https://nifi.example.com
-    username: nifiuser
-    password: 123456
-    labels:
-      env: production
-    caCertificates: |
-      -----BEGIN CERTIFICATE-----
-      MIICLDCCAdKgAwIBAgIBADAKBggqhkjOPQQDAjB9MQswCQYDVQQGEwJCRTEPMA0G
-      A1UEChMGR251VExTMSUwIwYDVQQLExxHbnVUTFMgY2VydGlmaWNhdGUgYXV0aG9y
-      aXR5MQ8wDQYDVQQIEwZMZXV2ZW4xJTAjBgNVBAMTHEdudVRMUyBjZXJ0aWZpY2F0
-      ZSBhdXRob3JpdHkwHhcNMTEwNTIzMjAzODIxWhcNMTIxMjIyMDc0MTUxWjB9MQsw
-      CQYDVQQGEwJCRTEPMA0GA1UEChMGR251VExTMSUwIwYDVQQLExxHbnVUTFMgY2Vy
-      dGlmaWNhdGUgYXV0aG9yaXR5MQ8wDQYDVQQIEwZMZXV2ZW4xJTAjBgNVBAMTHEdu
-      dVRMUyBjZXJ0aWZpY2F0ZSBhdXRob3JpdHkwWTATBgcqhkjOPQIBBggqhkjOPQMB
-      BwNCAARS2I0jiuNn14Y2sSALCX3IybqiIJUvxUpj+oNfzngvj/Niyv2394BWnW4X
-      uQ4RTEiywK87WRcWMGgJB5kX/t2no0MwQTAPBgNVHRMBAf8EBTADAQH/MA8GA1Ud
-      DwEB/wQFAwMHBgAwHQYDVR0OBBYEFPC0gf6YEr+1KLlkQAPLzB9mTigDMAoGCCqG
-      SM49BAMCA0gAMEUCIDGuwD1KPyG+hRf88MeyMQcqOFZD0TbVleF+UsAGQ4enAiEA
-      l4wOuDwKQa+upc8GftXE2C//4mKANBC6It01gUaTIpo=
-      -----END CERTIFICATE-----
+   - url: http://test-nifi.example.com:8080
+     username: nifitest
+     password: abc123
+     labels:
+       env: testing
+   - url: https://nifi.example.com
+     username: nifiuser
+     password: 123456
+     labels:
+       env: production
+     caCertificates: |
+       -----BEGIN CERTIFICATE-----
+       MIICLDCCAdKgAwIBAgIBADAKBggqhkjOPQQDAjB9MQswCQYDVQQGEwJCRTEPMA0G
+       A1UEChMGR251VExTMSUwIwYDVQQLExxHbnVUTFMgY2VydGlmaWNhdGUgYXV0aG9y
+       aXR5MQ8wDQYDVQQIEwZMZXV2ZW4xJTAjBgNVBAMTHEdudVRMUyBjZXJ0aWZpY2F0
+       ZSBhdXRob3JpdHkwHhcNMTEwNTIzMjAzODIxWhcNMTIxMjIyMDc0MTUxWjB9MQsw
+       CQYDVQQGEwJCRTEPMA0GA1UEChMGR251VExTMSUwIwYDVQQLExxHbnVUTFMgY2Vy
+       dGlmaWNhdGUgYXV0aG9yaXR5MQ8wDQYDVQQIEwZMZXV2ZW4xJTAjBgNVBAMTHEdu
+       dVRMUyBjZXJ0aWZpY2F0ZSBhdXRob3JpdHkwWTATBgcqhkjOPQIBBggqhkjOPQMB
+       BwNCAARS2I0jiuNn14Y2sSALCX3IybqiIJUvxUpj+oNfzngvj/Niyv2394BWnW4X
+       uQ4RTEiywK87WRcWMGgJB5kX/t2no0MwQTAPBgNVHRMBAf8EBTADAQH/MA8GA1Ud
+       DwEB/wQFAwMHBgAwHQYDVR0OBBYEFPC0gf6YEr+1KLlkQAPLzB9mTigDMAoGCCqG
+       SM49BAMCA0gAMEUCIDGuwD1KPyG+hRf88MeyMQcqOFZD0TbVleF+UsAGQ4enAiEA
+       l4wOuDwKQa+upc8GftXE2C//4mKANBC6It01gUaTIpo=
+       -----END CERTIFICATE-----


### PR DESCRIPTION
Instead of returning the process groups that exist as direct children of the root process group:

1. Perform a depth-first tree traversal of the nifi process groups and surface all of them for scraping
2. At each process group, retrieve the connections information and for each connection, return its current flow-file length

I only surfaced this one metric for now as I'm looking to use it to monitor dead-letter / failure queues in our nifi deployment, however it should be easy for others to extend as required.